### PR TITLE
Update link to example spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module.exports = function(config) {
 }
 ```
 
-See [our example](https://github.com/riot/examples/karma-mocha) for Mocha spec config.
+See [our example](./test/specs.js) for Mocha spec config.
 
 ----
 


### PR DESCRIPTION
The link to the example spec is currently broken, and is dependant on what's happening in the examples repo. 

I've updated the link to point to the example contained in this repo.
